### PR TITLE
fix aspect autocomplete using unstable iterator.prototype.toArray()

### DIFF
--- a/js/builder/aspects.js
+++ b/js/builder/aspects.js
@@ -30,7 +30,7 @@ class AspectAutocompleteInitNode extends ComputeNode {
         if (active_class === null) return;
 
         active_aspects = aspect_map.get(active_class);
-        const class_aspect_names = active_aspects.keys().toArray();
+        const class_aspect_names = [...active_aspects.keys()];
 
         aspect_aliases = new Map();
         // Basically ported from builder.js:add_tome_autocomplete


### PR DESCRIPTION
This caused a crash on devices running uncompatible browser versions:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray#browser_compatibility