### PR TITLE
Fix unknown function reference in toggleAmps() in item.js

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -55,7 +55,7 @@ function toggleAmps(button_id) {
             amp_state = button_id;
         } 
     }    
-    displaysq2IDProbabilities("identification-probabilities", item, amp_state);
+    displayIDProbabilities("identification-probabilities", item, amp_state);
 }
 
 


### PR DESCRIPTION
Clicking any of the corkian amplifier buttons to change the amplifier state doesn't do anything.
## Example
Scroll down to apply a corkian amplifier on [Chained Pixels](https://wynnbuilder.github.io/item/#Chained%20Pixels)

The following is the problematic function call:
## Current
```js
// File: item.js
function toggleAmps(button_id) {
    // ...
    // supposed to reference displayIDProbabilities() in item_display.js
    displaysq2IDProbabilities("identification-probabilities", item, amp_state);
}
```

## Corrected
```js
// File: item.js
function toggleAmps(button_id) {
    // ...
    displayIDProbabilities("identification-probabilities", item, amp_state);
}
```